### PR TITLE
AVX-14851: AVX-14955: Add new input variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,60 @@
 # Azure Aviatrix - Terraform Module
 
 ## Descriptions
-This Terraform module allows you to launch the Aviatrix Controller and create the Aviatrix access account connecting to the existing Controller on Azure.
+
+This Terraform module allows you to launch the Aviatrix Controller and create the Aviatrix access account connecting to
+the existing Controller on Azure.
 
 ## Prerequisites
+
 1. [Terraform 0.13](https://www.terraform.io/downloads.html) - execute terraform files
-2. [Azure command-line interface (Azure CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) - Azure authentication
-3. [Python3](https://www.python.org/downloads/) - execute `accept_license.py` and `aviatrix_controller_init.py` python scripts
+2. [Azure command-line interface (Azure CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) - Azure
+   authentication
+3. [Python3](https://www.python.org/downloads/) - execute `accept_license.py` and `aviatrix_controller_init.py` python
+   scripts
 
 ## Available Modules
- Module  | Description |
+
+Module  | Description |
 | ------- | ----------- |
 |[aviatrix_controller_arm](./aviatrix_controller_arm) |Creates the Azure ARM such as Subscription ID, Directory ID, Application ID, and Application Key for Aviatrix access account setup |
 |[aviatrix_controller_build](./aviatrix_controller_build) |Builds the Aviatrix Controller VM on Azure |
 |[aviatrix_controller_initialize](./aviatrix_controller_initialize) | Initializes the Aviatrix Controller (setting admin email, setting admin password, upgrading controller version, and setting access account) |
 
-
 ## Procedures for Building and Initializing a Controller in Azure
+
 ### 1. Create the Python virtual environment and install required dependencies in the terminal
+
 ``` shell
  python3 -m venv venv
 ```
-This command will create the virtual environment. In order to use the virtual environment, it needs to be activated by the following command
+
+This command will create the virtual environment. In order to use the virtual environment, it needs to be activated by
+the following command
+
 ``` shell
  source venv/bin/activate
 ```
-In order to run these `accept_license.py` and `aviatrix_controller_init.py` python scripts, dependencies listed in `requirements.txt` need to be stalled by the following command
+
+In order to run these `accept_license.py` and `aviatrix_controller_init.py` python scripts, dependencies listed
+in `requirements.txt` need to be stalled by the following command
+
 ``` shell
  pip install -r requirements.txt
 ```
 
 ### 2. Authenticating to Azure using the Azure CLI in the terminal
+
 ``` shell
 az login
 ```
+
 This command will open the default browser and load Azure sign in page
 
 ### 3. Create the Azure ARM (Service Principal)
 
 **create_arm.tf**
+
 ```
 provider "azurerm" {
   version = "<< terraform version >>"
@@ -46,8 +62,7 @@ provider "azurerm" {
 }
 
 module "aviatrix_controller_arm" {
-  source                = "./aviatrix_controller_arm"
-  terraform_module_path = "<< absolute path of this terraform module >>"
+  source = "git@github.com:AviatrixSystems/terraform-module-azure/aviatrix_controller_arm.git"
 }
 
 output "subscription_id" {
@@ -66,7 +81,9 @@ output "application_key" {
   value = module.aviatrix_controller_arm.application_key
 }
 ```
+
 *Execute*
+
 ```shell
 cd aviatrix_controller_arm
 terraform init
@@ -77,6 +94,7 @@ cd ..
 ### 4. Build the Controller VM on Azure
 
 **build_controller.tf**
+
 ```
 provider "azurerm" {
   version = "<< terraform version >>"
@@ -84,7 +102,7 @@ provider "azurerm" {
 }
 
 module "aviatrix_controller_build" {
-  source          = "./aviatrix_controller_build"
+  source          = "git@github.com:AviatrixSystems/terraform-module-azure/aviatrix_controller_build.git"
   // please do not use special characters such as `\/"[]:|<>+=;,?*@&~!#$%^()_{}'` in the controller_name
   controller_name = "<< your Aviatroc Controller name >>"
 }
@@ -97,16 +115,20 @@ output "avx_controller_private_ip" {
   value = module.aviatrix_controller_build.aviatrix_controller_private_ip_address
 }
 ```
+
 *Execute*
+
 ```shell
 cd aviatrix_controller_build
 terraform init
 terraform apply
 cd ..
 ```
+
 ### 5. Initialize the Controller
 
 **controller_init.tf**
+
 ```
 provider "azurerm" {
   version = "<< terraform version >>"
@@ -114,7 +136,7 @@ provider "azurerm" {
 }
 
 module "aviatrix_controller_initialize" {
-  source                        = "./aviatrix_controller_initialize"
+  source                        = "git@github.com:AviatrixSystems/terraform-module-azure/aviatrix_controller_initialize.git"
   avx_controller_public_ip      = "<< public ip address of the Aviatrix Controller >>"
   avx_controller_private_ip     = "<< private ip address of the Aviatrix Controller >>"
   avx_controller_admin_email    = "<< your admin email address for the Aviatrix Controller >>"
@@ -126,10 +148,11 @@ module "aviatrix_controller_initialize" {
   account_email                 = "<< your email address for your access account >>"
   access_account_name           = "<< your account name mapping to your Azure account >>"
   aviatrix_customer_id          = "<< your customer license id >>"
-  terraform_module_path         = "<< absolute path of this terraform module >>"
 }
 ```
+
 *Execute*
+
 ```shell
 cd aviatrix_controller_initialize
 terraform init
@@ -138,7 +161,9 @@ cd ..
 ```
 
 ### Putting it all together
+
 The controller buildup and initialization can be done using a single terraform file.
+
 ```
 provider "azurerm" {
   version = "<< terraform version >>"
@@ -146,19 +171,18 @@ provider "azurerm" {
 }
 
 module "aviatrix_controller_arm" {
-  source                = "./aviatrix_controller_arm"
-  terraform_module_path = "<< absolute path of this terraform module >>"
+  source                = "git@github.com:AviatrixSystems/terraform-module-azure/aviatrix_controller_arm.git"
 }
 
 module "aviatrix_controller_build" {
-  source          = "./aviatrix_controller_build"
+  source          = "git@github.com:AviatrixSystems/terraform-module-azure/aviatrix_controller_build.git"
   // please do not use special characters such as `\/"[]:|<>+=;,?*@&~!#$%^()_{}'` in the controller_name
   controller_name = "<< your Aviatrix Controller name >>"
   depends_on      = [module.aviatrix_controller_arm]
 }
 
 module "aviatrix_controller_initialize" {
-  source                        = "./aviatrix_controller_initialize"
+  source                        = "git@github.com:AviatrixSystems/terraform-module-azure/aviatrix_controller_initialize.git"
   avx_controller_public_ip      = module.aviatrix_controller_build.aviatrix_controller_public_ip_address
   avx_controller_private_ip     = module.aviatrix_controller_build.aviatrix_controller_private_ip_address
   avx_controller_admin_email    = "<< your admin email address for the Aviatrix Controller >>"
@@ -170,7 +194,6 @@ module "aviatrix_controller_initialize" {
   account_email                 = "<< your email address for your access account >>"
   access_account_name           = "<< your account name mapping to your Azure account >>"
   aviatrix_customer_id          = "<< your customer license id >>"
-  terraform_module_path         = "<< absolute path of this terraform module >>"
   depends_on                    = [module.aviatrix_controller_arm]
 }
 
@@ -194,7 +217,9 @@ output "avx_controller_public_ip" {
   value = module.aviatrix_controller_build.aviatrix_controller_public_ip_address
 }
 ```
+
 *Execute*
+
 ```shell
 terraform init
 terraform apply

--- a/aviatrix_controller_arm/main.tf
+++ b/aviatrix_controller_arm/main.tf
@@ -1,7 +1,7 @@
 // accept license of Aviatrix Controller
 resource "null_resource" "accept_license" {
   provisioner "local-exec" {
-    command = "python3 ${var.terraform_module_path == "" ? path.module : var.terraform_module_path}/accept_license.py"
+    command = "python3 ${var.terraform_module_path == "" ? path.module : format("%s/%s", var.terraform_module_path, "aviatrix_controller_arm")}/accept_license.py"
   }
 }
 

--- a/aviatrix_controller_build/main.tf
+++ b/aviatrix_controller_build/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_resource_group" "aviatrix_controller_rg" {
 //  Create the Virtual Network
 resource "azurerm_virtual_network" "aviatrix_controller_vnet" {
   address_space = [
-  "10.0.0.0/24"]
+  var.controller_vnet_cidr]
   location            = var.location
   name                = "${var.controller_name}-vnet"
   resource_group_name = azurerm_resource_group.aviatrix_controller_rg.name
@@ -20,7 +20,7 @@ resource "azurerm_subnet" "aviatrix_controller_subnet" {
   resource_group_name  = azurerm_resource_group.aviatrix_controller_rg.name
   virtual_network_name = azurerm_virtual_network.aviatrix_controller_vnet.name
   address_prefixes = [
-  "10.0.0.0/24"]
+  var.controller_subnet_cidr]
 }
 
 // 3. Create Public IP Address
@@ -66,15 +66,15 @@ resource "azurerm_network_interface" "aviatrix_controller_nic" {
 
 # 6. Create the virtual machine
 resource "azurerm_linux_virtual_machine" "aviatrix_controller_vm" {
-  admin_username                  = "aviatrix"
-  admin_password                  = "aviatrix1234!"
+  admin_username                  = var.controller_virtual_machine_admin_username
+  admin_password                  = var.controller_virtual_machine_admin_password
   name                            = "${var.controller_name}vm"
   disable_password_authentication = false
   location                        = azurerm_resource_group.aviatrix_controller_rg.location
   network_interface_ids = [
   azurerm_network_interface.aviatrix_controller_nic.id]
   resource_group_name = azurerm_resource_group.aviatrix_controller_rg.name
-  size                = "Standard_A4_v2"
+  size                = var.controller_virtual_machine_size
   //disk
   os_disk {
     name                 = "aviatrix-os-disk"

--- a/aviatrix_controller_build/variables.tf
+++ b/aviatrix_controller_build/variables.tf
@@ -8,3 +8,33 @@ variable "controller_name" {
   type        = string
   description = "Customized Name for Aviatrix Controller"
 }
+
+variable "controller_vnet_cidr" {
+  type        = string
+  description = "CIDR for controller VNET."
+  default     = "10.0.0.0/24"
+}
+
+variable "controller_subnet_cidr" {
+  type        = string
+  description = "CIDR for controller subnet."
+  default     = "10.0.0.0/24"
+}
+
+variable "controller_virtual_machine_admin_username" {
+  type        = string
+  description = "Admin Username for the controller virtual machine."
+  default     = "aviatrix"
+}
+
+variable "controller_virtual_machine_admin_password" {
+  type        = string
+  description = "Admin Password for the controller virtual machine."
+  default     = "aviatrix1234!"
+}
+
+variable "controller_virtual_machine_size" {
+  type        = string
+  description = "Virtual Machine size for the controller."
+  default     = "Standard_A4_v2"
+}

--- a/aviatrix_controller_initialize/aviatrix_controller_init.py
+++ b/aviatrix_controller_initialize/aviatrix_controller_init.py
@@ -838,6 +838,7 @@ if __name__ == "__main__":
     account_email = sys.argv[9]
     access_account_name = sys.argv[10]
     aviatrix_customer_id = sys.argv[11]
+    controller_version = sys.argv[12]
 
     event = {
         "hostname": hostname,
@@ -846,7 +847,7 @@ if __name__ == "__main__":
         "aviatrix_api_route": "api",
         "admin_email": admin_email,
         "new_admin_password": new_admin_password,
-        "controller_init_version": "latest",
+        "controller_init_version": controller_version,
         "arm_subscription_id": arm_subscription_id,
         "arm_application_client_id": arm_application_client_id,
         "arm_application_client_secret": arm_application_client_secret,
@@ -861,6 +862,4 @@ if __name__ == "__main__":
     except Exception as e:
         logging.exception("")
     else:
-        logging.info(
-            "Aviatrix Controller %s has been initialized successfully", ucc_public_ip
-        )
+        logging.info("Aviatrix Controller has been initialized successfully")

--- a/aviatrix_controller_initialize/main.tf
+++ b/aviatrix_controller_initialize/main.tf
@@ -1,12 +1,12 @@
 locals {
-  option = format("%s/aviatrix_controller_initialize/aviatrix_controller_init.py",
-    var.terraform_module_path == "" ? path.module : var.terraform_module_path
+  option = format("%s/aviatrix_controller_init.py",
+    var.terraform_module_path == "" ? path.module : format("%s/%s", var.terraform_module_path, "aviatrix_controller_initialize")
   )
-  argument = format("'%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s'",
+  argument = format("'%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s'",
     var.avx_controller_public_ip, var.avx_controller_private_ip, var.avx_controller_admin_email,
     var.avx_controller_admin_password, var.arm_subscription_id, var.arm_application_id,
     var.arm_application_key, var.directory_id, var.account_email, var.access_account_name,
-    var.aviatrix_customer_id
+    var.aviatrix_customer_id, var.controller_version
   )
 }
 resource "null_resource" "run_script" {

--- a/aviatrix_controller_initialize/variables.tf
+++ b/aviatrix_controller_initialize/variables.tf
@@ -45,7 +45,7 @@ variable "account_email" {
 
 variable "access_account_name" {
   type        = string
-  description = "aviatirx controller access account name"
+  description = "aviatrix controller access account name"
 }
 
 variable "aviatrix_customer_id" {
@@ -57,4 +57,10 @@ variable "terraform_module_path" {
   type        = string
   description = "terraform module absolute path"
   default     = ""
+}
+
+variable "controller_version" {
+  type        = string
+  description = "Aviatrix Controller version"
+  default     = "latest"
 }


### PR DESCRIPTION
Added new input variables:
aviatrix_controller_build:
- controller_vnet_cidr
- controller_subnet_cidr
- controller_virtual_machine_admin_username
- controller_virtual_machine_admin_password
- controller_virtual_machine_size
aviatrix_controller_init:
- controller_version

Also updated the README to use github source path and remove use of
terraform_module_path input variable.

Also fixed some module path issues.